### PR TITLE
feat: Rollback to v3 to add colors

### DIFF
--- a/takoyaki_bin/Cargo.toml
+++ b/takoyaki_bin/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-clap = "4.0.18"
+clap = "3.2.23"
 colored = "2.0.0"
 reqwest = { version = "0.11", features = ["json"] }
 tokio = { version = "1", features = ["full"] }
@@ -16,3 +16,4 @@ serde = { version = "1.0", features = ["derive"] }
 throbber = "0.1"
 inquire = "0.4.0"
 anyhow = "1.0.66"
+


### PR DESCRIPTION
This PR rolls back to v3.x for the colored from v4.x because of no colored output (colored output looks better).

Most probably it is gonna be till clap.rs adds styling option in v4

There is no breaking change, so this PR is good to be merged :) 